### PR TITLE
Use a set for the list to avoid duplicates

### DIFF
--- a/cmd/ghactions/list.go
+++ b/cmd/ghactions/list.go
@@ -18,11 +18,8 @@ package ghactions
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 
-	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 
 	"github.com/stacklok/frizbee/pkg/ghactions"
 )
@@ -49,21 +46,9 @@ Example:
 func list(cmd *cobra.Command, _ []string) error {
 	dir := cmd.Flag("dir").Value.String()
 
-	base := filepath.Base(dir)
-	bfs := osfs.New(filepath.Dir(dir), osfs.WithBoundOS())
-	actions := []ghactions.Action{}
-
-	err := ghactions.TraverseGitHubActionWorkflows(bfs, base, func(path string, wflow *yaml.Node) error {
-		wfActions, err := ghactions.ListActionsInYAML(wflow)
-		if err != nil {
-			return fmt.Errorf("failed to get actions from YAML file %s: %w", path, err)
-		}
-		actions = append(actions, wfActions...)
-
-		return nil
-	})
+	actions, err := ghactions.ListActionsInDirectory(dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list actions: %w", err)
 	}
 
 	jsonBytes, err := json.MarshalIndent(actions, "", "  ")

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/deckarep/golang-set/v2 v2.3.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53E
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.3.1 h1:vjmkvJt/IV27WXPyYQpAh4bRyWJc5Y435D17XQ9QU5A=
+github.com/deckarep/golang-set/v2 v2.3.1/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+mTU=
 github.com/go-git/go-billy/v5 v5.5.0/go.mod h1:hmexnoNsr2SJU1Ju67OaNz5ASJY3+sHgFRpCtpDCKow=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=

--- a/pkg/ghactions/ghactions.go
+++ b/pkg/ghactions/ghactions.go
@@ -20,8 +20,11 @@ package ghactions
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/google/go-github/v56/github"
 	"gopkg.in/yaml.v3"
 
@@ -139,8 +142,8 @@ type Action struct {
 }
 
 // ListActionsInYAML returns a list of actions referenced in the given YAML structure.
-func ListActionsInYAML(node *yaml.Node) ([]Action, error) {
-	var uses []Action
+func setOfActions(node *yaml.Node) (mapset.Set[Action], error) {
+	actions := mapset.NewSet[Action]()
 	foundUses := false
 
 	for _, v := range node.Content {
@@ -156,19 +159,60 @@ func ListActionsInYAML(node *yaml.Node) ([]Action, error) {
 				return nil, fmt.Errorf("failed to parse action reference '%s': %w", v.Value, err)
 			}
 
-			uses = append(uses, *a)
+			actions.Add(*a)
 			continue
 		}
 
 		// Otherwise recursively look more
-		childUses, err := ListActionsInYAML(v)
+		childUses, err := setOfActions(v)
 		if err != nil {
 			return nil, err
 		}
-		uses = append(uses, childUses...)
+		actions = actions.Union(childUses)
 	}
 
-	return uses, nil
+	return actions, nil
+}
+
+// ListActionsInYAML returns a list of actions referenced in the given YAML structure.
+func ListActionsInYAML(node *yaml.Node) ([]Action, error) {
+	// just convert the set to a slice
+	actions, err := setOfActions(node)
+	if err != nil {
+		return nil, err
+	}
+
+	return setAsSlice[Action](actions), nil
+}
+
+// ListActionsInDirectory returns a list of actions referenced in the given directory.
+func ListActionsInDirectory(dir string) ([]Action, error) {
+	base := filepath.Base(dir)
+	bfs := osfs.New(filepath.Dir(dir), osfs.WithBoundOS())
+	actions := mapset.NewSet[Action]()
+
+	err := TraverseGitHubActionWorkflows(bfs, base, func(path string, wflow *yaml.Node) error {
+		wfActions, err := setOfActions(wflow)
+		if err != nil {
+			return fmt.Errorf("failed to get actions from YAML file %s: %w", path, err)
+		}
+
+		actions = actions.Union(wfActions)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return setAsSlice[Action](actions), nil
+}
+
+func setAsSlice[T comparable](s mapset.Set[T]) []T {
+	res := make([]T, 0, s.Cardinality())
+	for item := range s.Iter() {
+		res = append(res, item) // Type assertion to T
+	}
+	return res
 }
 
 func parseValue(val string) (*Action, error) {


### PR DESCRIPTION
I was being silly and did just appended blindly to a single slice which resulted in duplicates. Using a set seems like the cleanest option. On the API boundary, a plain slice is returned (I don't like returning 3rd party types from a public API..). There's also a new function to list all actions in a directory what I think the majority of users would like (except when parsing patches).