### PR TITLE
Add full action name in list

### DIFF
--- a/pkg/ghactions/ghactions.go
+++ b/pkg/ghactions/ghactions.go
@@ -133,9 +133,10 @@ func ModifyReferencesInYAML(ctx context.Context, ghcli *github.Client, node *yam
 
 // Action represents an action reference.
 type Action struct {
-	Owner string
-	Repo  string
-	Ref   string
+	Action string
+	Owner  string
+	Repo   string
+	Ref    string
 }
 
 // ListActionsInYAML returns a list of actions referenced in the given YAML structure.
@@ -183,9 +184,10 @@ func parseValue(val string) (*Action, error) {
 	}
 
 	return &Action{
-		Owner: owner,
-		Repo:  repo,
-		Ref:   ref,
+		Action: action,
+		Owner:  owner,
+		Repo:   repo,
+		Ref:    ref,
 	}, nil
 }
 


### PR DESCRIPTION
The action list has the repo and the owner of the action, but the fact is that a repo
may hold more than one action at a time. To address this, this adds the actual action
string to the list, which should now hold a unique reference.
