### PR TITLE
Add README and project information

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at <code-of-conduct@stacklok.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+
+# Contributing to Frizbee
+First off, thank you for taking the time to contribute to Frizbee! :+1: :tada: Frizbee is released under the Apache 2.0 license. If you would like to contribute something or want to hack on the code, this document should help you get started. You can find some hints for starting development in Frizbee's  [README](https://github.com/stacklok/frizbee/blob/main/README.md).
+
+## Table of contents 
+- [Code of Conduct](#code-of-conduct)
+- [Reporting Security Vulnerabilities](#reporting-security-vulnerabilities)
+- [How to Contribute](#how-to-contribute)
+  - [Sign the Contributor License Agreement](#sign-the-contributor-license-agreement)
+  - [Using GitHub Issues](#using-github-issues)
+  - [Not sure how to start contributing...](#not-sure-how-to-start-contributing)
+  - [Pull Request Process](#pull-request-process)
+  - [Contributing to docs](#contributing-to-docs)
+  - [Commit Message Guidelines](#commit-message-guidelines)
+  
+
+## Code of Conduct
+This project adheres to the [Contributor Covenant](https://github.com/stacklok/frizbee/blob/main/CODE_OF_CONDUCT.md) code of conduct. By participating, you are expected to uphold this code. Please report unacceptable behavior to code-of-conduct@stacklok.dev.
+
+## Reporting Security Vulnerabilities
+
+If you think you have found a security vulnerability in Frizbee please DO NOT disclose it publicly until we’ve had a chance to fix it. Please don’t report security vulnerabilities using GitHub issues; instead, please follow this [process](https://github.com/stacklok/frizbee/blob/main/SECURITY.md)
+
+## How to Contribute
+
+### Using GitHub Issues
+We use GitHub issues to track bugs and enhancements. If you have a general usage question, please ask in [Frizbee's discussion forum](https://github.com/stacklok/frizbee/discussions). 
+
+If you are reporting a bug, please help to speed up problem diagnosis by providing as much information as possible. Ideally, that would include a small sample project that reproduces the problem.
+
+### Sign the Contributor License Agreement
+Before we accept a non-trivial patch or pull request, we will need you to sign the [Contributor License Agreement](https://github.com/stacklok/frizbee). Signing the contributor’s agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do. Active contributors might be asked to join the core team and given the ability to merge pull requests.
+
+### Not sure how to start contributing...
+PRs to resolve existing issues are greatly appreciated and issues labeled as ["good first issue"](https://github.com/stacklok/frizbee/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) are a great place to start!
+
+### Pull Request Process
+* Create an issue outlining the fix or feature.
+* Fork the Frizbee repository to your own GitHub account and clone it locally.
+* Hack on your changes.
+* Correctly format your commit messages, see [Commit Message Guidelines](#Commit-Message-Guidelines) below.
+* Open a PR by ensuring the title and its description reflect the content of the PR.
+* Ensure that CI passes, if it fails, fix the failures.
+* Every pull request requires a review from the core Frizbee team before merging.
+* Once approved, all of your commits will be squashed into a single commit with your PR title.
+
+### Contributing to docs
+Follow [this guide](https://github.com/stacklok/frizbee/blob/main/docs/README.md) for instructions on building, running, and previewing Miner's documentation.
+
+### Commit Message Guidelines
+We follow the commit formatting recommendations found on [Chris Beams' How to Write a Git Commit Message article](https://chris.beams.io/posts/git-commit/).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,92 @@
 # Frizbee
 
-frizbee is a tool you may throw a tag at and it comes back with a checksum.
+Frizbee is a tool you may throw a tag at and it comes back with a checksum.
+
+It's a command-line tool designed to provide checksums for GitHub Actions
+and container images based on tags.
 
 It also includes a set of libraries for working with tags and checksums.
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+  - [GitHub Actions](#github-actions)
+  - [Container Images](#container-images)
+- [Configuration](#configuration)
+- [Commands](#commands)
+- [Autocompletion](#autocompletion)
+- [Contributing](#contributing)
+- [License](#license)
+
+## Installation
+
+To install Frizbee, you can use the following methods:
+
+```bash
+# Using Go
+go get -u github.com/stacklok/frizbee
+go install github.com/stacklok/frizbee
+
+# Using Homebrew
+brew install stacklok/tap/frizbee
+
+# Using winget
+winget install stacklok.frizbee
+```
+
+## Usage
+
+### GitHub Actions
+
+Frizbee can be used to generate checksums for GitHub Actions. This is useful
+for verifying that the contents of a GitHub Action have not changed.
+
+To quickly replace the GitHub Action references for your project, you can use
+the `ghactions` command:
+
+```bash
+frizbee ghactions -d path/to/your/repo/.github/workflows/
+```
+
+This will write all the replacements to the files in the directory provided.
+
+Note that this command will only replace the `uses` field of the GitHub Action
+references.
+
+Note that this command supports dry-run mode, which will print the replacements
+to stdout instead of writing them to the files.
+
+It also supports exiting with a non-zero exit code if any replacements are found. 
+This is handy for CI/CD pipelines.
+
+If you want to generate the replacement for a single GitHub Action, you can use
+the `ghactions one` command:
+
+```bash
+frizbee ghactions one metal-toolbox/container-push/.github/workflows/container-push.yml@main
+```
+
+This is useful if you're developing and want to quickly test the replacement.
+
+### Container Images
+
+Frizbee can be used to generate checksums for container images. This is useful
+for verifying that the contents of a container image have not changed.
+
+To get the digest for a single image tag, you can use the `containerimage one` command:
+
+```bash
+frizbee containerimage one quay.io/stacklok/frizbee:latest
+```
+
+This will print the image refrence with the digest for the image tag provided.
+
+
+## Contributing
+
+We welcome contributions to Frizbee. Please see our [Contributing](./CONTRIBUTING.md) guide for more information.
+
+## License
+
+Frizbee is licensed under the [Apache 2.0 License](./LICENSE).


### PR DESCRIPTION
This adds the relevant project information to the README, as well as a
code of conduct and contributing guidelines.

Closes: https://github.com/stacklok/frizbee/issues/5
