### PR TITLE
Add `kubernetes` and `docker-compose` sub-commands

### DIFF
--- a/cmd/dockercompose/dockercompose.go
+++ b/cmd/dockercompose/dockercompose.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package containerimage provides command-line utilities to work with container images.
-package containerimage
+// Package dockercompose provides command-line utilities to work with container images.
+package dockercompose
 
 import (
 	"fmt"
@@ -24,25 +24,24 @@ import (
 	"github.com/stacklok/frizbee/pkg/config"
 )
 
-// CmdYAML represents the yaml sub-command
-func CmdYAML() *cobra.Command {
+// CmdCompose represents the compose yaml sub-command
+func CmdCompose() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "yaml",
-		Short: "Replace container image references with checksums in YAML files",
+		Use:     "docker-compose",
+		Aliases: []string{"dockercompose", "compose"},
+		Short:   "Replace container image references with checksums in docker-compose YAML files",
 		Long: `This utility replaces a tag or branch reference in a container image references
-with the digest hash of the referenced tag in YAML files.
+with the digest hash of the referenced tag in docker-compose YAML files.
 
 Example:
 
-	$ frizbee containerimage yaml --dir . --dry-run --quiet --error
+	$ frizbee docker-compose --dir . --dry-run --quiet --error
 `,
 		RunE:         replaceYAML,
 		SilenceUsage: true,
 	}
 
 	// flags
-	cmd.Flags().StringP("image-regex", "i", "image", "regex to match container image references")
-
 	intcmd.DeclareYAMLReplacerFlags(cmd)
 
 	return cmd
@@ -53,12 +52,8 @@ func replaceYAML(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get config from context: %w", err)
 	}
-	ir, err := cmd.Flags().GetString("image-regex")
-	if err != nil {
-		return fmt.Errorf("failed to get image-regex flag: %w", err)
-	}
 
-	replacer, err := intcmd.NewYAMLReplacer(cmd, intcmd.WithImageRegex(ir))
+	replacer, err := intcmd.NewYAMLReplacer(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/kubernetes/kubernetes.go
+++ b/cmd/kubernetes/kubernetes.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package containerimage provides command-line utilities to work with container images.
-package containerimage
+// Package kubernetes provides command-line utilities to work with kubernetes manifests.
+package kubernetes
 
 import (
 	"fmt"
@@ -24,17 +24,18 @@ import (
 	"github.com/stacklok/frizbee/pkg/config"
 )
 
-// CmdYAML represents the yaml sub-command
-func CmdYAML() *cobra.Command {
+// CmdK8s represents the k8s yaml sub-command
+func CmdK8s() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "yaml",
-		Short: "Replace container image references with checksums in YAML files",
+		Use:     "kubernetes",
+		Aliases: []string{"k8s"},
+		Short:   "Replace container image references with checksums in kubernetes YAML files",
 		Long: `This utility replaces a tag or branch reference in a container image references
 with the digest hash of the referenced tag in YAML files.
 
 Example:
 
-	$ frizbee containerimage yaml --dir . --dry-run --quiet --error
+	$ frizbee kubernetes --dir . --dry-run --quiet --error
 `,
 		RunE:         replaceYAML,
 		SilenceUsage: true,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stacklok/frizbee/cmd/containerimage"
+	"github.com/stacklok/frizbee/cmd/dockercompose"
 	"github.com/stacklok/frizbee/cmd/ghactions"
+	"github.com/stacklok/frizbee/cmd/kubernetes"
 	"github.com/stacklok/frizbee/pkg/config"
 )
 
@@ -40,6 +42,8 @@ func Execute() {
 
 	rootCmd.AddCommand(ghactions.CmdGHActions())
 	rootCmd.AddCommand(containerimage.CmdContainerImage())
+	rootCmd.AddCommand(dockercompose.CmdCompose())
+	rootCmd.AddCommand(kubernetes.CmdK8s())
 
 	if err := rootCmd.ExecuteContext(context.Background()); err != nil {
 		os.Exit(1)

--- a/internal/cmd/doc.go
+++ b/internal/cmd/doc.go
@@ -1,0 +1,17 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmd provide common implementations for commands
+package cmd


### PR DESCRIPTION
These sub-commands are pretty much the same functionality as the `containerimage yaml`
sub-command. The main idea is that they are easier to figure out and type. The kubernetes
sub-command takes the "image regex" argument, which allows one to use an alternative
key to fetch a container image from a manifest. The `docker-compose` sub-command doesn't;
It'll just look for the `image` key in the YAML and attempt to replace that.
