### PR TITLE
`ghactions list`: skip local references from list

### DIFF
--- a/pkg/ghactions/ghactions.go
+++ b/pkg/ghactions/ghactions.go
@@ -176,6 +176,12 @@ func setOfActions(node *yaml.Node) (mapset.Set[Action], error) {
 
 		if foundUses {
 			foundUses = false
+
+			// If the value is a local path, skip it
+			if IsLocal(v.Value) {
+				continue
+			}
+
 			a, err := parseValue(v.Value)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse action reference '%s': %w", v.Value, err)


### PR DESCRIPTION
This skips local references from the list sub-command, since these
are not relevant. We'll parse them anyway and output their inner actions
which is what we really care about.

We have a similar mechanism for the replacer piece of `ghactions`.

Closes: #39
