### PR TITLE
Add descriptions to task targets

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,13 +3,16 @@ version: '3'
 
 tasks:
   test:
+    desc: Run tests
     cmds:
       - go test -v ./...
 
   build:
+    desc: Build the frizbee binary
     cmds:
       - go build -o ./bin/ ./...
 
   lint:
+    desc: Run linter
     cmds:
       - golangci-lint run --timeout 5m0s --config .golangci.yml


### PR DESCRIPTION
This adds relevant description so doing `task -l` will list all targets and what they do.
