### PR TITLE
Use GitHub token for doing frizbee CI check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,3 +93,5 @@ jobs:
       - name: Frizbee
         run: |-
           bin/frizbee ghactions --dry-run --error
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is added to increase the rate limit of GitHub API calls.