### PR TITLE
Output informaiton about the `GITHUB_TOKEN` env variable in relevant commands

### DIFF
--- a/cmd/ghactions/common.go
+++ b/cmd/ghactions/common.go
@@ -1,0 +1,26 @@
+//
+// Copyright 2023 Stacklok, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ghactions
+
+const (
+	// GitHubTokenEnvKey is the environment variable key for the GitHub token
+	//nolint:gosec // This is not a hardcoded credential
+	GitHubTokenEnvKey = "GITHUB_TOKEN"
+
+	// TokenHelpText is the help text for the GitHub token
+	TokenHelpText = "NOTE: It's recommended to set the " + GitHubTokenEnvKey +
+		" environment variable given that GitHub has tighter rate limits on anonymous calls."
+)

--- a/cmd/ghactions/ghactions.go
+++ b/cmd/ghactions/ghactions.go
@@ -41,7 +41,8 @@ Example:
 
 This will replace all tag or branch references in all GitHub Actions workflows
 for the given directory.
-`,
+
+` + TokenHelpText + "\n",
 		RunE:         replace,
 		SilenceUsage: true,
 	}
@@ -81,7 +82,7 @@ func replace(cmd *cobra.Command, _ []string) error {
 
 	ctx := cmd.Context()
 
-	ghcli := ghrest.NewGhRest(os.Getenv("GITHUB_TOKEN"))
+	ghcli := ghrest.NewGhRest(os.Getenv(GitHubTokenEnvKey))
 
 	replacer := &replacer{
 		Replacer: cliutils.Replacer{

--- a/cmd/ghactions/one.go
+++ b/cmd/ghactions/one.go
@@ -39,7 +39,8 @@ Example:
 
 This will replace the tag or branch reference for the commit hash of the
 referenced tag or branch.
-`,
+
+` + TokenHelpText + "\n",
 		Args:         cobra.ExactArgs(1),
 		RunE:         replaceOne,
 		SilenceUsage: true,
@@ -52,7 +53,7 @@ func replaceOne(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	ref := args[0]
 
-	ghcli := ghrest.NewGhRest(os.Getenv("GITHUB_TOKEN"))
+	ghcli := ghrest.NewGhRest(os.Getenv(GitHubTokenEnvKey))
 
 	act, ref, err := ghactions.ParseActionReference(ref)
 	if err != nil {


### PR DESCRIPTION
This makes it easier to discover that this variable is possible to use.

The code now also has a constant to refer to this variable.
