### PR TITLE
Allow excluding just the action name

### DIFF
--- a/pkg/ghactions/ghactions.go
+++ b/pkg/ghactions/ghactions.go
@@ -123,6 +123,10 @@ func ModifyReferencesInYAMLWithCache(
 				return modified, fmt.Errorf("failed to parse action reference '%s': %w", v.Value, err)
 			}
 
+			if shouldExclude(cfg, act) {
+				continue
+			}
+
 			var sum string
 
 			// Check if we have a cached value


### PR DESCRIPTION
Frizbee allowed to exclude the whole action name including the tag e.g. `actions/checkout@v4`. But this is not user-friendly for cases where the exclude would be upgraded over time as the exclude would have to be kept in sync.

Let's also support the case where the exclude is just in the form of `owner/action_name`.