### PR TITLE
Use version to return `version` sub-command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ func Execute() {
 	rootCmd.AddCommand(containerimage.CmdContainerImage())
 	rootCmd.AddCommand(dockercompose.CmdCompose())
 	rootCmd.AddCommand(kubernetes.CmdK8s())
-	rootCmd.AddCommand(version.CmdVersion)
+	rootCmd.AddCommand(version.CmdVersion())
 
 	if err := rootCmd.ExecuteContext(context.Background()); err != nil {
 		os.Exit(1)

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -23,12 +23,13 @@ import (
 )
 
 // CmdVersion is the Cobra command for the version command.
-// nolint: gochecknoglobals
-var CmdVersion = &cobra.Command{
-	Use:   "version",
-	Short: "Print frizbee CLI version",
-	Long:  "The frizbee version command prints the version of the frizbee CLI.",
-	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Println(constants.VerboseCLIVersion)
-	},
+func CmdVersion() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print frizbee CLI version",
+		Long:  "The frizbee version command prints the version of the frizbee CLI.",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Println(constants.VerboseCLIVersion)
+		},
+	}
 }


### PR DESCRIPTION
This removes the usage of a global variable
