### PR TITLE
GitHub Actions: Don't call GH API if action is already commit-referenced

### DIFF
--- a/pkg/ghactions/ghactions.go
+++ b/pkg/ghactions/ghactions.go
@@ -54,6 +54,11 @@ func GetChecksum(ctx context.Context, restIf interfaces.REST, action, ref string
 		return "", err
 	}
 
+	// Check if we're using a checksum
+	if isChecksum(ref) {
+		return ref, nil
+	}
+
 	res, err := getCheckSumForTag(ctx, restIf, owner, repo, ref)
 	if err != nil {
 		return "", fmt.Errorf("failed to get checksum for tag: %w", err)
@@ -69,12 +74,7 @@ func GetChecksum(ctx context.Context, restIf interfaces.REST, action, ref string
 		return res, nil
 	}
 
-	// Check if we're using a checksum
-	if len(ref) != 40 {
-		return "", ErrInvalidActionReference
-	}
-
-	return ref, nil
+	return "", ErrInvalidActionReference
 }
 
 // ModifyReferencesInYAML takes the given YAML structure and replaces
@@ -264,4 +264,9 @@ func shouldExclude(cfg *config.GHActions, input string) bool {
 		}
 	}
 	return false
+}
+
+// isChecksum returns true if the input is a checksum.
+func isChecksum(ref string) bool {
+	return len(ref) == 40
 }


### PR DESCRIPTION
If the GitHub Action is already referenced via a commit or checksum, we
don't need to call GH to verify if it's a tag or a branch. This
effectively reduces the number of calls to GH to 0 in the best case.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
