### PR TITLE
Fix version variable path in goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,7 @@ builds:
       - "-X main.Commit={{ .Env.COMMIT }}"
       - "-X main.CommitDate={{ .Env.COMMIT_DATE }}"
       - "-X main.TreeState={{ .Env.TREE_STATE }}"
-      - "-X github.com/stacklok/frizbee/pkg/constants.CLIVersion={{ .Env.VERSION }}"
+      - "-X github.com/stacklok/frizbee/internal/cli.CLIVersion={{ .Env.VERSION }}"
     goos:
       - linux
       - windows


### PR DESCRIPTION
The package had changed and we forgot to change it.

Related-To: https://github.com/stacklok/frizbee/issues/143

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
