### PR TITLE
chore: improve release binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,7 @@ builds:
       - -trimpath
       - -tags=netgo
     ldflags:
+      - "-s -w"
       - "-X main.Version={{ .Env.VERSION }}"
       - "-X main.Commit={{ .Env.COMMIT }}"
       - "-X main.CommitDate={{ .Env.COMMIT_DATE }}"


### PR DESCRIPTION
improve the release binary with linker flags `-s -w`, would shrink the binary by 1/3
```
$ go build -o frizbee_normal

$ ls -lh frizbee_normal
-rwxr-xr-x  1 rui  staff    18M Jul 15 14:10 frizbee_normal

$ go build -ldflags="-s -w" -o frizbee_stripped

$ ls -lh frizbee_stripped
-rwxr-xr-x  1 rui  staff    12M Jul 15 14:11 frizbee_stripped
```

