### PR TITLE
Only ignore main and master, not all branches when pinning actions

### DIFF
--- a/pkg/utils/config/config.go
+++ b/pkg/utils/config/config.go
@@ -98,7 +98,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		GHActions: GHActions{
 			Filter: Filter{
-				ExcludeBranches: []string{"*"},
+				ExcludeBranches: []string{"main", "master"},
 			},
 		},
 		Images: Images{

--- a/pkg/utils/config/config_test.go
+++ b/pkg/utils/config/config_test.go
@@ -137,7 +137,7 @@ images:
 				GHActions: GHActions{
 					Filter: Filter{
 						Exclude:         []string{"pattern1", "pattern2"},
-						ExcludeBranches: []string{"*"},
+						ExcludeBranches: []string{"main", "master"},
 					},
 				},
 				Images: Images{


### PR DESCRIPTION
We used to ignore all actions that were referenced with a branch, but
this is not really intuitive. Let's only ignore main and master.

Relates: #175
