### PR TITLE
Use unchanging version tag in tests

### DIFF
--- a/pkg/replacer/actions/actions_test.go
+++ b/pkg/replacer/actions/actions_test.go
@@ -292,9 +292,9 @@ func TestGetChecksum(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "bufbuild/buf-setup-action with v1 is an array",
-			args:    struct{ action, ref string }{action: "bufbuild/buf-setup-action", ref: "v1"},
-			want:    "35c243d7f2a909b1d4e40399b348a7fdab27d78d",
+			name:    "actions/setup-node with v1 is an array",
+			args:    struct{ action, ref string }{action: "actions/setup-node", ref: "v1"},
+			want:    "f1f314fca9dfce2769ece7d933488f076716723e",
 			wantErr: false,
 		},
 		{

--- a/pkg/replacer/replacer_test.go
+++ b/pkg/replacer/replacer_test.go
@@ -343,13 +343,13 @@ func TestReplacer_ParseGitHubActionString(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "bufbuild/buf-setup-action with v1 is an array",
+			name: "actions/setup-node with v1 is an array",
 			args: args{
-				action: "bufbuild/buf-setup-action@v1",
+				action: "actions/setup-node@v1",
 			},
 			want: &interfaces.EntityRef{
-				Name:   "bufbuild/buf-setup-action",
-				Ref:    "35c243d7f2a909b1d4e40399b348a7fdab27d78d",
+				Name:   "actions/setup-node",
+				Ref:    "f1f314fca9dfce2769ece7d933488f076716723e",
 				Type:   actions.ReferenceType,
 				Tag:    "v1",
 				Prefix: "",


### PR DESCRIPTION
This uses an old action version in our tests, that is no longer receiving updates. This ensures that newer versions will not be released for this specific tag and the reference will always be the same.
The previously used action `actions/setup-node` received an update and no longer pointed to the same reference.