### PR TITLE
Add cert string to goreleaser configuration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -105,3 +105,4 @@ signs:
       - "--yes" # needed on cosign 2.0.0+
     artifacts: archive
     output: true
+    certificate: '{{ trimsuffix (trimsuffix .Env.artifact ".zip") ".tar.gz" }}.pem'


### PR DESCRIPTION
This is needed for goreleaser to actually output the cert

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
