### PR TITLE
Patch 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ To install Frizbee, you can use the following methods:
 # Using Go
 go get -u github.com/stacklok/frizbee
 go install github.com/stacklok/frizbee
+# add the path to your .bashrc
+export PATH=$PATH:$(go env GOPATH)/bin
+
+
 
 # Using Homebrew
 brew install frizbee

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ To install Frizbee, you can use the following methods:
 
 ```bash
 # Using Go
-go get -u github.com/stacklok/frizbee
-go install github.com/stacklok/frizbee
+go install github.com/stacklok/frizbee@v0.1.2
 # add the path to your .bashrc
 export PATH=$PATH:$(go env GOPATH)/bin
 


### PR DESCRIPTION
As I was struggling with the installation (as a non GO user), I added this to the Readme, so it will maybe help others

- adds the frizbee path to your PATH
- `go get -u github.com/stacklok/frizbee` 
'go get' is no longer supported outside a module.

- go: 'go install' requires a version when current directory is not in a module