### PR TITLE
Temporarily disable publishing to winget

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,38 +33,38 @@ archives:
       - goos: windows
         format: zip
 # This section defines how to release to winget.
-winget:
-  - name: frizbee
-    publisher: stacklok
-    license: Apache-2.0
-    license_url: "https://github.com/stacklok/frizbee/blob/main/LICENSE"
-    copyright: Stacklok, Inc.
-    homepage: https://stacklok.com
-    short_description: 'frizbee is a tool you may throw a tag at and it comes back with a checksum.'
-    publisher_support_url: "https://github.com/stacklok/frizbee/issues/new/choose"
-    package_identifier: "stacklok.frizbee"
-    url_template: "https://github.com/stacklok/frizbee/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-    skip_upload: auto
-    release_notes: "{{.Changelog}}"
-    tags:
-      - golang
-      - cli
-    commit_author:
-      name: stacklokbot
-      email: info@stacklok.com
-    goamd64: v1
-    repository:
-      owner: stacklok
-      name: winget-pkgs
-      branch: "frizbee-{{.Version}}"
-      token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
-      pull_request:
-        enabled: true
-        draft: false
-        base:
-          owner: microsoft
-          name: winget-pkgs
-          branch: master
+# winget:
+#   - name: frizbee
+#     publisher: stacklok
+#     license: Apache-2.0
+#     license_url: "https://github.com/stacklok/frizbee/blob/main/LICENSE"
+#     copyright: Stacklok, Inc.
+#     homepage: https://stacklok.com
+#     short_description: 'frizbee is a tool you may throw a tag at and it comes back with a checksum.'
+#     publisher_support_url: "https://github.com/stacklok/frizbee/issues/new/choose"
+#     package_identifier: "stacklok.frizbee"
+#     url_template: "https://github.com/stacklok/frizbee/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+#     skip_upload: auto
+#     release_notes: "{{.Changelog}}"
+#     tags:
+#       - golang
+#       - cli
+#     commit_author:
+#       name: stacklokbot
+#       email: info@stacklok.com
+#     goamd64: v1
+#     repository:
+#       owner: stacklok
+#       name: winget-pkgs
+#       branch: "frizbee-{{.Version}}"
+#       token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
+#       pull_request:
+#         enabled: true
+#         draft: false
+#         base:
+#           owner: microsoft
+#           name: winget-pkgs
+#           branch: master
 # This section defines whether we want to release the source code too.
 source:
   enabled: true


### PR DESCRIPTION
The following PR temporarily disables publishing to winget. This broke because we migrated the winget-pkg repo to mindersec. 

Let's disable this for now so we can fix the release process and enable it after the holidays.