### PR TITLE
chore: update golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,4 @@
 run:
-  go: "1.21"
   issues-exit-code: 1
   timeout: 5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,13 +53,13 @@ linters:
     - bidichk
     - bodyclose
     - contextcheck
+    - copyloopvar
     - decorder
     - dogsled
     - dupl
     - errcheck
     - errname
     - exhaustive
-    - exportloopref
     - forbidigo
     - forcetypeassert
     - gci

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -46,8 +46,6 @@ func TestNewHelper(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -129,8 +127,6 @@ func TestProcessOutput(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -204,8 +200,6 @@ func TestIsPath(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/traverse/traverse_test.go
+++ b/internal/traverse/traverse_test.go
@@ -86,8 +86,6 @@ func TestYamlDockerfiles(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -155,8 +153,6 @@ func TestTraverse(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -234,8 +230,6 @@ func TestIsYAMLOrDockerfile(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/replacer/actions/actions_test.go
+++ b/pkg/replacer/actions/actions_test.go
@@ -45,7 +45,6 @@ func TestSetAndGetRegex(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -74,7 +73,6 @@ func TestReplaceLocalPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -104,7 +102,6 @@ func TestReplaceExcludedPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -131,7 +128,6 @@ func TestConvertToEntityRef(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -160,7 +156,6 @@ func TestIsLocal(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -184,7 +179,6 @@ func TestShouldExclude(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -208,7 +202,6 @@ func TestParseActionReference(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -306,7 +299,6 @@ func TestGetChecksum(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/replacer/image/image_test.go
+++ b/pkg/replacer/image/image_test.go
@@ -21,7 +21,6 @@ func TestNewParser(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			parser := New()
@@ -43,7 +42,6 @@ func TestSetCache(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			parser := New()
@@ -64,7 +62,6 @@ func TestSetAndGetRegex(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			parser := New()
@@ -141,7 +138,6 @@ func TestReplaceExcludedPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := parser.Replace(ctx, tt.matchedLine, nil, cfg)
@@ -171,7 +167,6 @@ func TestConvertToEntityRef(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ref, err := parser.ConvertToEntityRef(tt.reference)
@@ -219,7 +214,6 @@ func TestGetImageDigestFromRef(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := GetImageDigestFromRef(ctx, tt.refstr, "", nil)
@@ -253,7 +247,6 @@ func TestShouldSkipImage(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/replacer/replacer_test.go
+++ b/pkg/replacer/replacer_test.go
@@ -189,7 +189,6 @@ func TestReplacer_ParseContainerImageString(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -394,7 +393,6 @@ func TestReplacer_ParseGitHubActionString(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -719,7 +717,6 @@ CMD ["dex", "serve", "/etc/dex/config.docker.yaml"]
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -948,7 +945,6 @@ jobs:
 		},
 	}
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -994,7 +990,6 @@ func TestReplacer_NewGitHubActionsReplacer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := NewGitHubActionsReplacer(tt.cfg)
@@ -1017,7 +1012,6 @@ func TestReplacer_NewContainerImagesReplacer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := NewContainerImagesReplacer(tt.cfg)
@@ -1040,7 +1034,6 @@ func TestReplacer_WithGitHubClient(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r = r.WithGitHubClientFromToken(tt.token)
@@ -1062,7 +1055,6 @@ func TestReplacer_WithUserRegex(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r = r.WithUserRegex(tt.regex)
@@ -1082,7 +1074,6 @@ func TestReplacer_WithCacheDisabled(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r = r.WithCacheDisabled()
@@ -1106,7 +1097,6 @@ func TestReplacer_ParsePathInFS(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := r.ParsePathInFS(context.Background(), fs, tt.base)
@@ -1133,7 +1123,6 @@ func TestReplacer_ListPathInFS(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := r.ListPathInFS(fs, tt.base)
@@ -1286,7 +1275,6 @@ spec:
 		},
 	}
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := NewContainerImagesReplacer(&config.Config{})
@@ -1441,7 +1429,6 @@ jobs:
 		},
 	}
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := NewGitHubActionsReplacer(&config.Config{}).WithGitHubClientFromToken(os.Getenv(cli.GitHubTokenEnvKey))

--- a/pkg/utils/config/config_test.go
+++ b/pkg/utils/config/config_test.go
@@ -38,8 +38,6 @@ func TestFromCommand(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -129,7 +127,7 @@ images:
   exclude_images:
     - notthisone
   exclude_tags:
-    - notthistag	
+    - notthistag
 `,
 			},
 			expectedResult: &Config{
@@ -157,8 +155,6 @@ images:
 	}
 
 	for _, tt := range testCases {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/utils/ghrest/ghrest_test.go
+++ b/pkg/utils/ghrest/ghrest_test.go
@@ -66,8 +66,6 @@ func TestClientFunctions(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
-
 		if tt.mockResponse != nil {
 			defer gock.Off()
 			//gock.DisableNetworking()

--- a/pkg/utils/store/cache_test.go
+++ b/pkg/utils/store/cache_test.go
@@ -64,8 +64,6 @@ func TestCacher(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
- chore(golangci): remove `go` version as it would default to go version in `go.mod`
- chore: replace deprecated `exportloopref` with `copyloopvar`