### PR TITLE
Add SARIF output and upload to Trivy workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,6 +28,6 @@ jobs:
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@45775bd8235c68ba998cffa5171334d58593da47 # v3
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -6,7 +6,10 @@ on:
 jobs:
   trivy-code-security-scan:
     runs-on: ubuntu-latest
-    name: Trivy 
+    name: Trivy
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -17,7 +20,14 @@ jobs:
           scanners: vuln,secret
           exit-code: 1
           ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This PR adds SARIF output format to the Trivy workflow and uses the upload-sarif action to upload the results to GitHub's security dashboard.