### PR TITLE
fix: strip quotes from uses field

### DIFF
--- a/pkg/replacer/actions/actions_test.go
+++ b/pkg/replacer/actions/actions_test.go
@@ -217,6 +217,125 @@ func TestParseActionReference(t *testing.T) {
 	}
 }
 
+func TestParseActionReference_WithQuotes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		input          string
+		expectedAction string
+		expectedRef    string
+		expectError    bool
+	}{
+		{
+			name:           "quoted action reference",
+			input:          "'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f'",
+			expectedAction: "google-github-actions/auth",
+			expectedRef:    "6fc4af4b145ae7821d527454aa9bd537d1f2dc5f",
+			expectError:    false,
+		},
+		{
+			name:           "double quoted action reference",
+			input:          "\"google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f\"",
+			expectedAction: "google-github-actions/auth",
+			expectedRef:    "6fc4af4b145ae7821d527454aa9bd537d1f2dc5f",
+			expectError:    false,
+		},
+		{
+			name:           "unquoted action reference",
+			input:          "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f",
+			expectedAction: "google-github-actions/auth",
+			expectedRef:    "6fc4af4b145ae7821d527454aa9bd537d1f2dc5f",
+			expectError:    false,
+		},
+		{
+			name:        "invalid action reference",
+			input:       "invalid-action-reference",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			action, ref, err := ParseActionReference(tc.input)
+
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedAction, action)
+			require.Equal(t, tc.expectedRef, ref)
+		})
+	}
+}
+
+func TestConvertToEntityRef_WithQuotes(t *testing.T) {
+	t.Parallel()
+
+	parser := New()
+
+	testCases := []struct {
+		name         string
+		input        string
+		expectedName string
+		expectedRef  string
+		expectedType string
+		expectError  bool
+	}{
+		{
+			name:         "quoted action reference with uses prefix",
+			input:        "uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f'",
+			expectedName: "google-github-actions/auth",
+			expectedRef:  "6fc4af4b145ae7821d527454aa9bd537d1f2dc5f",
+			expectedType: "action",
+			expectError:  false,
+		},
+		{
+			name:         "double quoted action reference with uses prefix",
+			input:        "uses: \"google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f\"",
+			expectedName: "google-github-actions/auth",
+			expectedRef:  "6fc4af4b145ae7821d527454aa9bd537d1f2dc5f",
+			expectedType: "action",
+			expectError:  false,
+		},
+		{
+			name:         "unquoted action reference with uses prefix",
+			input:        "uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f",
+			expectedName: "google-github-actions/auth",
+			expectedRef:  "6fc4af4b145ae7821d527454aa9bd537d1f2dc5f",
+			expectedType: "action",
+			expectError:  false,
+		},
+		{
+			name:        "invalid action reference",
+			input:       "uses: invalid-action-reference",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := parser.ConvertToEntityRef(tc.input)
+
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedName, result.Name)
+			require.Equal(t, tc.expectedRef, result.Ref)
+			require.Equal(t, tc.expectedType, result.Type)
+		})
+	}
+}
+
 func TestGetChecksum(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When running frizbee against https://github.com/cloudnative-pg/cloudnative-pg I noticed that the output looked a bit funny:

```yaml
› frizbee actions list
+----+--------+------------------------------------------+-------------------------------------------+
| NO |  TYPE  |                   NAME                   |                    REF                    |
+----+--------+------------------------------------------+-------------------------------------------+
|  1 | action | 'google-github-actions/auth              | 6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' |
|  2 | action | actions-cool/check-user-permission       | 7b90a27f92f3961b368376107661682c441f6103  |
|  3 | action | actions-ecosystem/action-add-labels      | 18f1af5e3544586314bbe15c0273249c770b2daf  |
[...]
```

As the `name` and `ref` fields carry the leading and trailing quote used in the [original workflow](https://github.com/cloudnative-pg/cloudnative-pg/blob/5246abb4d0240382a58f3df59a35a1348375348a/.github/workflows/k8s-versions-check.yml#L64).

This PR removes the quotes when parsing the uses field.

Happy for any feedback! Especially if this the right place to fix the bug, as I had to apply the fix in two places, i.e., `ConvertToEntityRef` and `ParseActionReference`.