### PR TITLE
fix(ci): remove duplicate cache key in releaser workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,6 @@ jobs:
         go-version: 'stable'
         cache: true
 
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
@@ -65,7 +64,6 @@ jobs:
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -69,7 +69,6 @@ jobs:
         with:
           go-version: 'stable'
           cache: true
-          cache: true
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
           go-version: 'stable'
           cache: true
 
-
       - name: setup task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
@@ -52,7 +51,6 @@ jobs:
           go-version: 'stable'
           cache: true
 
-
       - name: setup task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
@@ -80,7 +78,6 @@ jobs:
           go-version: 'stable'
           cache: true
 
-
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
 
@@ -95,7 +92,6 @@ jobs:
         with:
           go-version: 'stable'
           cache: true
-
 
       - name: setup task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0


### PR DESCRIPTION
**Hotfix — `main` currently has an invalid workflow file and the release pipeline is broken.**

## What happened

#444 switched every `setup-go` step from `go-version-file: ./go.mod` to `go-version: 'stable'` + `cache: true`. `releaser.yml` **already had** `cache: true`, so it came out with the key twice:

```yaml
      - name: Setup Go
        uses: actions/setup-go@b7ad1dad… # v7
        with:
          go-version: 'stable'
          cache: true
          cache: true     # <-- duplicate
```

GitHub rejects the entire file as an invalid workflow. That's the jobless failing `Release` run on the merge commit ([run 31756816798](https://github.com/stacklok/frizbee/actions/runs/31756816798)) — 0 jobs, immediate failure, workflow shown by file path rather than by its `name:`. **The next tag push would not have released anything.**

## Why nothing caught it

Three independent gaps lined up:

1. **`releaser.yml` only triggers on `push: tags`**, so no PR check ever parsed it. All 9 checks on #444 were green and stayed green — they simply never looked at this file.
2. **PyYAML accepts duplicate keys silently** (last one wins), so validating with `yaml.safe_load` reported the file as fine, and printed a collapsed `{'go-version': 'stable', 'cache': True}`.
3. A `grep -A3` spot-check window stopped exactly one line short of the second `cache: true`.

`actionlint` catches it precisely:

```
releaser.yml:72:11: key "cache" is duplicated in "with" section.
  previously defined at line:71,col:11 [syntax-check]
```

## This change

* Removes the duplicate `cache: true` from `releaser.yml`
* Collapses the stray double blank lines the same rewrite left in `test.yml` and `codeql.yml` (cosmetic, same root cause)

Deletions only — 7 lines, no behaviour change beyond making the file valid again.

## Verification

| Check | Result |
|---|---|
| `actionlint` on all 5 workflows | no syntax/schema errors (only pre-existing shellcheck style notes in untouched `run:` blocks) |
| strict YAML load, duplicate keys rejected | all 5 files OK |
| `actionlint` on the current `main` version | reproduces the error above, confirming the diagnosis |

## Follow-up worth doing

The real gap is that **`releaser.yml` is never validated on PRs**. Adding an `actionlint` step to the `lint` job would parse every workflow file on every PR and would have caught this before merge. Happy to send that as a separate PR — left out here to keep the hotfix trivially reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)